### PR TITLE
Fix base path for GitHub Pages deployment

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -12,8 +12,7 @@ const routes = [
 ]
 
 const router = createRouter({
-    // history: createWebHistory(import.meta.env.BASE_URL),
-    history: createWebHistory('/portfolio/'),
+    history: createWebHistory(import.meta.env.BASE_URL),
     routes,
 })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,6 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vite.dev/config/
 export default defineConfig({
-  // base: '/',
-  base : '/portfolio/',
+  base: '/portfolio/',
   plugins: [vue()],
 })


### PR DESCRIPTION
## Summary
- set `base` to `/portfolio/` in `vite.config.ts`
- keep router using `import.meta.env.BASE_URL`

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b91a583648330b5a42e672a7f8555